### PR TITLE
Add an option to resolve the hostname in the url (puppeteer-core:connect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ puppeteer-core:browser_alias_name?param1=value&param2=value&param3=value
 
 `puppeteer-core:connect` connects to a remote Chromium instance through the DevTools Protocol.
 
-Parameter:
+Parameters:
 - `url`: the url to connect to the remote Chromium instance (defaults to `http://127.0.0.1:9222`).
+- `resolve`: whether or not to resolve the hostname in the url as a workaround to the issue described in GoogleChrome/puppeteer#2242 (defaults to false).
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ puppeteer-core:browser_alias_name?param1=value&param2=value&param3=value
 
 Parameters:
 - `url`: the url to connect to the remote Chromium instance (defaults to `http://127.0.0.1:9222`).
-- `resolve`: whether or not to resolve the hostname in the url as a workaround to the issue described in GoogleChrome/puppeteer#2242 (defaults to false).
+- `resolve`: whether or not to resolve the hostname in the url as a workaround to the issue described in [GoogleChrome/puppeteer#2242](https://github.com/GoogleChrome/puppeteer/issues/2242) (defaults to false).
 
 Example:
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,18 @@ export default {
 
             switch (action) {
                 case 'connect':
+                    var url = new URL(params.url || 'http://127.0.0.1:9222');
+
+                    // see: https://github.com/GoogleChrome/puppeteer/issues/2242
+                    if (params.resolve === 'true') {
+                        const dns = require('dns').promises;
+                        const { address: address } = await dns.lookup(url.hostname);
+
+                        url.hostname = address;
+                    }
+
                     this._browsers[browserName] = await puppeteer.connect({
-                        browserURL: params.url || 'http://127.0.0.1:9222'
+                        browserURL: url.toString()
                     });
                     break;
 


### PR DESCRIPTION
Add an option resolve the hostname in the url as a workaround to the issue described in [GoogleChrome/puppeteer#2242].