### PR TITLE
closeBrowser method does not close the browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ export default {
 
         // if it's the last page, close the browser
         if ((await this._browsers[browserName].pages()).length === 0) {
-            await this._browsers.close();
+            await this._browsers[browserName].close();
             delete this._browsers[browserName];
         }
     },


### PR DESCRIPTION
Hi,

I've tried your puppeteer-core browser provider, but in my testrun it wouldn't close the browser.
This small commit changes this behaviour so the browser is closed.

I ran the test on macOs Catalina with Testcafe 1.6.0 and the latest revision of Chromium.